### PR TITLE
Corrected renaming of RSPs when uninstalling a costume, prevent error…

### DIFF
--- a/Lib/BrawlInstallerLib.py
+++ b/Lib/BrawlInstallerLib.py
@@ -2583,7 +2583,7 @@ def subtractCSPs(cosmeticId, rspLoading="false", position=0, skipPositions=[]):
 				i = 0
 				for child in texFolder.Children:
 					i += 1
-					child.Name = 'MenSelchrFaceB.' + addLeadingZeros(str(i), 3)
+					child.Name = 'MenSelchrFaceB.' + addLeadingZeros(str((cosmeticId * 10) + i), 3)
 			if rspLoading == "false":
 				# Export RSP while we're at it
 				bresNode.Compression = "None"

--- a/Lib/InstallLib.py
+++ b/Lib/InstallLib.py
@@ -700,8 +700,9 @@ def installCharacter(fighterId="", cosmeticId=0, franchiseIconId=-1, auto=False,
 							installStockIcons(cosmeticId, stockIconFolder, "Misc Data [8]", "", filePath='/pf/menu2/if_adv_mngr.pac', fiftyCC="false", firstOnly=True)
 						if franchiseIconFolder and doInstallFranchiseIcon:
 							franchisIconFolderSse = Directory.GetDirectories(franchiseIconFolder.FullName, "Black")
-							if len(Directory.GetFiles(franchisIconFolderSse[0], "*.png")) > 0:
-								installFranchiseIcon(franchiseIconId, Directory.GetFiles(franchisIconFolderSse[0], "*.png")[0], '/pf/menu2/if_adv_mngr.pac')
+							if franchiseIconFolderSse:
+								if len(Directory.GetFiles(franchisIconFolderSse[0], "*.png")) > 0:
+									installFranchiseIcon(franchiseIconId, Directory.GetFiles(franchisIconFolderSse[0], "*.png")[0], '/pf/menu2/if_adv_mngr.pac')
 						fileOpened = checkOpenFile("if_adv_mngr")
 						if fileOpened:
 							BrawlAPI.SaveFile()


### PR DESCRIPTION
… when installing characters with invalid franchise icon folder setups